### PR TITLE
Fix sdist on 2.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
-Version 0.3
-===========
+Version 3.1 (2017-08-20)
+========================
+
+* Fix error that prevent sdist builds on 2.7
+
+
+Version 0.3 (2017-08-20)
+========================
 
 * Drop official support for Python 3.3
 * Deprecate implicit decoration on class based views via the requirements attribute

--- a/setup.py
+++ b/setup.py
@@ -26,17 +26,17 @@ class ToxTest(TestCommand):
         sys.exit(errno)
 
 
-with open('README.rst', 'r', encoding='utf-8') as f:
+with open('README.rst', 'r') as f:
     readme = f.read()
 
-with open('CHANGELOG', 'r', encoding='utf-8') as f:
+with open('CHANGELOG', 'r') as f:
     changelog = f.read()
 
 
 if __name__ == "__main__":
     setup(
         name='flask-allows',
-        version='0.3.0',
+        version='0.3.1',
         author='Alec Nikolas Reiter',
         author_email='alecreiter@gmail.com',
         description='Impose authorization requirements on Flask routes',


### PR DESCRIPTION
Encoding is an invalid keyword on 2.7, omit it for now since there are no non-ascii characters in either file.