### PR TITLE
Add docs about transitioning from user-request to user only requirements

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,3 +28,4 @@ Helpers
 =======
 
 .. autofunction:: flask_allows.views.requires
+.. autofunction:: flask_allows.requirements.wants_request

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -246,7 +246,7 @@ them as needed.
 
     If your requirement does not need the request object, the
     only change to make is to remove the parameter. If your requirement does
-    need the requirement you may either remove the default value and Allows
+    need the request object you may either remove the default value and Allows
     will determine that you have provided a user-request requirement, or you
     may remove the parameter altogether and import ``request`` directly from
     Flask.

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -250,3 +250,8 @@ them as needed.
     will determine that you have provided a user-request requirement, or you
     may remove the parameter altogether and import ``request`` directly from
     Flask.
+
+    Additionally, there is :meth:`~flask_allows.requirements.wants_request`
+    which marks the requirement as user only but passes the current request
+    behind the scenes. This decorator is intended only to assist during a
+    transitionary phase and will be remove in flask-allows 1.0

--- a/src/flask_allows/__init__.py
+++ b/src/flask_allows/__init__.py
@@ -1,7 +1,7 @@
 from .allows import Allows, allows  # noqa
 from .permission import Permission  # noqa
-from .requirements import Or  # noqa
-from .requirements import And, C, ConditionalRequirement, Not, Requirement
+from .requirements import (And, C, ConditionalRequirement, Not, Or,
+                           Requirement, wants_request)  # noqa
 from .views import PermissionedMethodView, PermissionedView, requires  # noqa
 
 __all__ = (
@@ -17,6 +17,7 @@ __all__ = (
     'PermissionedView'
     'Requirement',
     'requires',
+    'wants_request',
 )
 
 __version__ = "0.5.0"

--- a/src/flask_allows/requirements.py
+++ b/src/flask_allows/requirements.py
@@ -1,7 +1,9 @@
 import operator
 from abc import ABCMeta, abstractmethod
 from flask._compat import with_metaclass
+from flask import request
 from .allows import _call_requirement
+from functools import wraps
 
 
 class Requirement(with_metaclass(ABCMeta)):
@@ -155,3 +157,23 @@ class ConditionalRequirement(Requirement):
 
 (C, And, Or, Not) = (ConditionalRequirement, ConditionalRequirement.And,
                      ConditionalRequirement.Or, ConditionalRequirement.Not)
+
+
+def wants_request(f):
+    """
+    Helper decorator for transitioning to user-only requirements, this aids
+    in situations where the request may be marked optional and causes an
+    incorrect flow into user-only requirements.
+
+    This decorator causes the requirement to look like a user-only requirement
+    but passes the current request context internally to the requirement.
+
+    This decorator is intended only to assist during a transitionary phase
+    and will be removed in flask-allows 1.0
+
+    See: justanr/flask-allows #20 and justanr/flask-allows #27
+    """
+    @wraps(f)
+    def wrapper(user):
+        return f(user, request)
+    return wrapper

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,9 @@ commands =
 
 [pytest]
 norecursedirs = .tox .git .cache *.egg
-addopts = -vvl --flake8 --capture fd
+addopts = -vvl --flake8 --capture fd --strict
+markers =
+    regression: issue found that has been corrected but could arise again
 
 [flake8]
 ignore = E731


### PR DESCRIPTION
References #31

Paging @unuseless and @jkelley05

You both raised questions and concerns about this transition, so it seems like I've not communicated a transition plan clearly. Or rather at all. That's my bad and ended up with broken tests in at least one situation.

Hopefully this addition to the documentation resolves the lack of communication.

Ideally, removing the request parameter from your requirement definitions and importing `request` directly from Flask in the same module will be enough to alleviate issues. I can't personally think of a situation where this wouldn't work, but if you have one I'm more than happy to include it.

I've also included a section about the scenario that @jkelley05 brought to my attention -- a requirement with a default value provided to request -- which causes an incorrect flow into user only requirements.

I'd like to thank both of you for bringing to my attention.