### PR TITLE
Include repr of the requirement in deprecation warning

### DIFF
--- a/src/flask_allows/allows.py
+++ b/src/flask_allows/allows.py
@@ -10,6 +10,7 @@ from werkzeug.local import LocalProxy
 from .additional import Additional, AdditionalManager
 from .overrides import Override, OverrideManager
 
+
 __all__ = ("Allows", "allows")
 
 
@@ -237,8 +238,8 @@ def _call_requirement(req, user, request):
         return req(user)
     except TypeError:
         warnings.warn(
-            "Passing request to requirements is now deprecated"
-            " and will be removed in 1.0",
+            "{!r}: Passing request to requirements is now deprecated"
+            " and will be removed in 1.0".format(req),
             DeprecationWarning,
             stacklevel=2,
         )

--- a/test/test_allows.py
+++ b/test/test_allows.py
@@ -11,14 +11,17 @@ def test_warns_about_request_deprecation_with_old_style_requirement(member):
     import warnings
 
     allows = Allows(identity_loader=lambda: member)
+    req = lambda u, p: True  # noqa: E731
+    repred = repr(req)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", DeprecationWarning)
-        allows.fulfill([lambda u, r: True])
+        allows.fulfill([req])
         warnings.simplefilter("default", DeprecationWarning)
 
     assert len(w) == 1
     assert issubclass(w[0].category, DeprecationWarning)
+    assert str(w[0].message).startswith(repred)
     assert "Passing request to requirements is now deprecated" in str(w[0].message)
 
 


### PR DESCRIPTION
paging @cerealcable 

It's possible to make the warning issue a more precise location of where the bad requirement is with some work with inspect to get the module and source line the misbehaving requirement is. But I'd rather avoid that since I suspect it'll be finicky and maybe not 100% compat between 2 and 3.

Running with `PYTHONWARNINGS=always::DeprecationWarning:flask_allows.allows` in the environment will display all deprecation warnings that come out of this (rather than using `default` which won't show them or `error` which throws exceptions).