### PR TITLE
Expands wants request to class, removes request from classes

### DIFF
--- a/src/flask_allows/allows.py
+++ b/src/flask_allows/allows.py
@@ -10,7 +10,6 @@ from werkzeug.local import LocalProxy
 from .additional import Additional, AdditionalManager
 from .overrides import Override, OverrideManager
 
-
 __all__ = ("Allows", "allows")
 
 
@@ -150,7 +149,7 @@ class Allows(object):
                 r for r in all_requirements if r not in self.overrides.current
             )
 
-        return all(_call_requirement(r, identity, request) for r in all_requirements)
+        return all(_call_requirement(r, identity) for r in all_requirements)
 
     def clear_all_overrides(self):
         """
@@ -233,18 +232,18 @@ def _make_callable(func_or_value):
     return func_or_value
 
 
-def _call_requirement(req, user, request):
+def _call_requirement(requirement, user):
     try:
-        return req(user)
+        return requirement(user)
     except TypeError:
         warnings.warn(
             "{!r}: Passing request to requirements is now deprecated"
-            " and will be removed in 1.0".format(req),
+            " and will be removed in 1.0".format(requirement),
             DeprecationWarning,
             stacklevel=2,
         )
 
-        return req(user, request)
+        return requirement(user, request)
 
 
 allows = LocalProxy(__get_allows, name="flask-allows")

--- a/src/flask_allows/requirements.py
+++ b/src/flask_allows/requirements.py
@@ -1,6 +1,8 @@
 import operator
 from abc import ABCMeta, abstractmethod
 from functools import wraps
+from inspect import isclass
+from types import FunctionType
 
 from flask import request
 from flask._compat import with_metaclass
@@ -27,7 +29,7 @@ class Requirement(with_metaclass(ABCMeta)):
     """
 
     @abstractmethod
-    def fulfill(self, user, request=None):
+    def fulfill(self, user):
         """
         Abstract method called to verify the requirement against the current
         user and request.
@@ -40,8 +42,8 @@ class Requirement(with_metaclass(ABCMeta)):
         """
         return NotImplemented
 
-    def __call__(self, user, request):
-        return _call_requirement(self.fulfill, user, request)
+    def __call__(self, user):
+        return _call_requirement(self.fulfill, user)
 
     def __repr__(self):
         return "<{}()>".format(self.__class__.__name__)
@@ -122,7 +124,7 @@ class ConditionalRequirement(Requirement):
         """
         return cls(*requirements, negated=True)
 
-    def fulfill(self, user, request):
+    def fulfill(self, user):
         reduced = None
 
         requirements = self.requirements
@@ -132,7 +134,7 @@ class ConditionalRequirement(Requirement):
             requirements = (r for r in requirements if r not in current_overrides)
 
         for r in requirements:
-            result = _call_requirement(r, user, request)
+            result = _call_requirement(r, user)
 
             if reduced is None:
                 reduced = result
@@ -195,23 +197,48 @@ class ConditionalRequirement(Requirement):
 )
 
 
-def wants_request(f):
+def wants_request(f_or_cls):
     """
     Helper decorator for transitioning to user-only requirements, this aids
     in situations where the request may be marked optional and causes an
     incorrect flow into user-only requirements.
 
     This decorator causes the requirement to look like a user-only requirement
-    but passes the current request context internally to the requirement.
-
-    This decorator is intended only to assist during a transitionary phase
-    and will be removed in flask-allows 1.0
+    but passes the current request context internally to the requirement. It
+    can be applied to a function requirement or a subclass of Requirement.
 
     See: :issue:`20,27`
     """
 
+    if isclass(f_or_cls) and issubclass(f_or_cls, Requirement):
+        return _class_wants_request(f_or_cls)
+
+    if isinstance(f_or_cls, FunctionType):
+        return _func_wants_request(f_or_cls)
+
+    raise TypeError(
+        "Expected a function or subclass of Requirement. Got {}".format(f_or_cls)
+    )
+
+
+def _func_wants_request(f):
     @wraps(f)
     def wrapper(user):
         return f(user, request)
 
     return wrapper
+
+
+class _OldStyleRequirement(Requirement):
+    """
+    Used to provide an adaptation bridge to requirements that want the user
+    and request provided to fulfill rather than just user.
+    """
+
+    def __call__(self, user):
+        return self.fulfill(user, request)
+
+
+def _class_wants_request(cls):
+    name = cls.__name__
+    return type(name, (_OldStyleRequirement, cls), {})

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,8 @@ max-line-length = 88
 
 [pytest]
 norecursedirs = .tox .git .cache *.egg htmlcov
-addopts = -vvl --capture fd --strict
+addopts = -vvl --capture fd --strict -W error:::flask_allows
+
 markers =
     regression: issue found that has been corrected but could arise again
     integration: used to run only integration tests


### PR DESCRIPTION
Considering just making this the 1.0 release.

Expands `wants_request` to also work on subclasses of Requirement rather than just functions:

```python
from flask_allows.requirements import wants_request

@wants_request
class OldKindOfRequirement(Requirement):
    def fulfill(self, user, request):
        return True
```

This adds a `__call__` method at the front of the MRO that accepts user and request.

In combination with this change, `Requirement.__call__` has been changed to only accept user. This change includes conditional requirements, which now only accept `user` but still use `_call_requirement` under the hood to compensate for functions and classes that still expect request to be passed but haven't been decorated with `wants_request`

`wants_request` will also become a permanent member of the public API since injecting the request into requirements is still useful for some instances and not having to depend on it statically is nice. `_call_requirement` will removed in the 1.0 release in place of `wants_request`